### PR TITLE
修复在ipad ios13中ua更改导致无法滑动

### DIFF
--- a/src/jroll.js
+++ b/src/jroll.js
@@ -29,8 +29,8 @@
     TSD: prefix + 'ransitionDuration',
     TFO: prefix + 'ransformOrigin',
     isAndroid: /android/.test(ua),
-    isIOS: /iphone|ipad/.test(ua),
-    isMobile: /mobile|phone|android|pad/.test(ua),
+    isIOS: /iphone|ipad|macintosh/.test(ua),
+    isMobile: /mobile|phone|android|pad|macintosh/.test(ua),
 
     // 判断浏览是否支持perspective属性，从而判断是否支持开启3D加速
     translateZ: (function (pre) {


### PR DESCRIPTION
ios13版本内ipad的ua从ipad更改成macintosh，导致绑定事件错误