### PR TITLE
openHarmony平板设备支持

### DIFF
--- a/src/jroll.js
+++ b/src/jroll.js
@@ -30,7 +30,7 @@
     TFO: prefix + 'ransformOrigin',
     isAndroid: /android/.test(ua),
     isIOS: /iphone|ipad|macintosh/.test(ua),
-    isMobile: /mobile|phone|android|pad|macintosh/.test(ua),
+    isMobile: /mobile|phone|android|pad|macintosh|tablet/.test(ua),
 
     // 判断浏览是否支持perspective属性，从而判断是否支持开启3D加速
     translateZ: (function (pre) {


### PR DESCRIPTION
麻烦支持一下，openHarmony平板设备的ua是Mozilla/5.0 (Tablet; OpenHarmony 5.0).....，并没有被识别为mobile设备